### PR TITLE
Postgis Integration und VectorTileServer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
   && apt-get install -y nodejs \
   && apt-get install -y yarn \
   && apt-get install -y wget \
+  && apt-get install -y libpq-dev \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /usr/src/*
 
@@ -31,8 +32,7 @@ RUN chmod +x bin/start-cron.sh
 COPY docker/unicorn.rb /app/config/unicorn.rb
 COPY docker/database.yml /app/config/database.yml
 
-# TODO: wie kann assets building ohne DB passieren?
-# RUN bundle exec rake assets:precompile
+RUN bundle exec rake DATABASE_URL=nulldb://user:pass@127.0.0.1/dbname assets:precompile
 
 ENTRYPOINT ["/app/docker/entrypoint.sh"]
 

--- a/Dockerfile.martin
+++ b/Dockerfile.martin
@@ -1,0 +1,3 @@
+FROM urbica/martin
+
+COPY docker/martin_config.yml /martin_config.yml

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,10 @@ gem "sass-rails", "~> 5.0"
 gem "uglifier", ">= 1.3.0"
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
+gem "activerecord-postgis-adapter"
+gem "activerecord-nulldb-adapter"
+
+gem "rgeo"
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder", "~> 2.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,11 @@ GEM
       activemodel (= 5.2.4.3)
       activesupport (= 5.2.4.3)
       arel (>= 9.0)
+    activerecord-nulldb-adapter (0.8.0)
+      activerecord (>= 5.2.0, < 7.1)
+    activerecord-postgis-adapter (5.2.3)
+      activerecord (~> 5.1)
+      rgeo-activerecord (~> 6.0)
     activestorage (5.2.4.3)
       actionpack (= 5.2.4.3)
       activerecord (= 5.2.4.3)
@@ -326,6 +331,10 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rgeo (2.3.1)
+    rgeo-activerecord (6.2.2)
+      activerecord (>= 5.0)
+      rgeo (>= 1.0.0)
     rollbar (2.21.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -448,6 +457,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  activerecord-nulldb-adapter
+  activerecord-postgis-adapter
   acts-as-taggable-on
   addressable
   ancestry (~> 2.1)
@@ -493,6 +504,7 @@ DEPENDENCIES
   rails-controller-testing
   rb-readline
   redis
+  rgeo
   rollbar
   rspec-rails
   ruby-debug-ide

--- a/app/models/data_resources/resource_modules/geo_location.rb
+++ b/app/models/data_resources/resource_modules/geo_location.rb
@@ -1,13 +1,21 @@
 # frozen_string_literal: true
 
 class GeoLocation < ApplicationRecord
-  belongs_to :geo_locateable, polymorphic: true
+  belongs_to :geo_locateable, polymorphic: true, optional: true
 
   validates_presence_of :latitude, :longitude
   validates :latitude, :longitude, numericality: true
 
+  before_save :store_postgis_coordinates
+
   def coordinates
     [longitude, latitude]
+  end
+
+  def store_postgis_coordinates
+    return unless latitude && longitude
+
+    self.coords = RGeo::Cartesian.factory(srid: 4326).point(longitude, latitude)
   end
 end
 

--- a/db/migrate/20211221110102_add_coords_to_geo_locations.rb
+++ b/db/migrate/20211221110102_add_coords_to_geo_locations.rb
@@ -1,0 +1,5 @@
+class AddCoordsToGeoLocations < ActiveRecord::Migration[5.2]
+  def change
+    add_column :geo_locations, :coords, :st_point, geographic: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_074408) do
+ActiveRecord::Schema.define(version: 2021_12_21_110102) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+  enable_extension "postgis"
 
   create_table "accessibility_informations", force: :cascade do |t|
     t.text "description"
@@ -242,6 +243,7 @@ ActiveRecord::Schema.define(version: 2021_11_30_074408) do
     t.bigint "geo_locateable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.geography "coords", limit: {:srid=>4326, :type=>"st_point", :geographic=>true}
     t.index ["geo_locateable_type", "geo_locateable_id"], name: "index_geo_locations_geo_locateable"
   end
 

--- a/doc/postgis.md
+++ b/doc/postgis.md
@@ -1,0 +1,23 @@
+# Links
+
+- https://github.com/rgeo/activerecord-postgis-adapter
+- https://tegola.io/documentation/ für Background Tiles
+- https://github.com/urbica/martin für Data Overlay Tiles
+
+
+# Setup einmalig im entryscript
+
+- bundle exec rake db:gis:setup
+
+
+# Bespiel Datensatz
+
+- lat: 52.546762, lng: 13.454414
+- geo = GeoLocation.new
+- geo.latitude = 52.546762
+- geo.longitude = 13.454414
+- geo.save
+- x=35217, y=21484, z=16
+- http://tile-server.smart-village.docker.localhost:5000/public.geo_locations/z/x/y.pbf
+- http://tile-server.smart-village.docker.localhost:5000/public.geo_locations/16/35217/21484.pbf
+- http://tile-server.smart-village.docker.localhost:5000/public.geo_locations/18/140869/85939.pbf

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,6 +1,15 @@
 version: '3.7'
 
 services:
+  tile_server:
+    build:
+      context: .
+      dockerfile: Dockerfile.martin
+    labels:
+      - traefik.enable=true
+      - traefik.docker.network=public
+      - traefik.port=5000
+      - traefik.frontend.rule=Host:tile-server.smart-village.docker.localhost
   app:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,20 @@
 version: '3.7'
 
 services:
+  tile_server:
+    image: urbica/martin
+    environment:
+      DATABASE_URL: postgres://bbnavihub@bbnavi-datahub-postgresql/bbnavihub
+    command: "martin --config /martin_config.yml"
+    ports:
+      - 5000:5000
+    configs:
+      - source: martin-config-yml
+        target: /martin_config.yml
+    networks:
+      - bbnavi-datahub-postgresql
+      - public
+
   redis:
     environment:
       ALLOW_EMPTY_PASSWORD: "yes"
@@ -94,11 +108,13 @@ services:
         condition: on-failure
 
   db:
-    image: 'postgres:10.3-alpine'
+    # image: 'postgres:10.3-alpine'
+    image: 'postgis/postgis:10-3.1'
     environment:
       POSTGRES_USER: bbnavihub
       POSTGRES_PASSWORT: bbnavihub
       POSTGRES_DB: bbnavihub
+      DATADIR: /var/lib/postgresql/data
     networks:
       bbnavi-datahub-postgresql:
         aliases:
@@ -123,6 +139,8 @@ configs:
   mainserver-common-master-key:
     external: true
   datahub-nginx-conf:
+    external: true
+  martin-config-yml:
     external: true
 
 networks:

--- a/docker/database.yml
+++ b/docker/database.yml
@@ -10,7 +10,7 @@
 #   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
 #
 default: &default
-  adapter: postgresql
+  adapter: postgis
   encoding: utf8
   pool: 5
   username: bbnavihub

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -9,10 +9,8 @@ dockerize -wait tcp://$DB -timeout 30s
 npm set audit false
 bundle exec rake db:migrate
 
-# TODO: Sobald Assets build im Dockerfile ohne DB funktioniert,
-# kann der Schritt hier entfernt werden
-bundle exec rake assets:precompile
 bundle exec rake graphql:schema:dump
+bundle exec rake db:gis:setup
 cp -r /app/public/* /assets/
 rm -f /unicorn.pid
 

--- a/docker/martin_config.yml
+++ b/docker/martin_config.yml
@@ -1,0 +1,102 @@
+---
+# The socket address to bind [default: 0.0.0.0:3000]
+listen_addresses: '0.0.0.0:5000'
+
+# Database connection string
+connection_string: 'postgres://bbnavihub@bbnavi-datahub-postgresql/bbnavihub'
+
+# Maximum connections pool size [default: 20]
+pool_size: 20
+
+# Connection keep alive timeout [default: 75]
+keep_alive: 75
+
+# Number of web server workers
+worker_processes: 8
+
+# Enable watch mode
+watch: false
+
+# Trust invalid certificates. This introduces significant vulnerabilities, and should only be used as a last resort.
+danger_accept_invalid_certs: false
+
+# Associative arrays of table sources
+table_sources:
+  public.geo_locations:
+    # Table source id (required)
+    id: public.geo_locations
+
+    # Table schema (required)
+    schema: public
+
+    # Table name (required)
+    table: geo_locations
+
+    # Geometry SRID (required)
+    srid: 4326
+
+    # Geometry column name (required)
+    geometry_column: coords
+
+    # Feature id column name
+    id_column: id
+
+    # An integer specifying the minimum zoom level
+    minzoom: 0
+
+    # An integer specifying the maximum zoom level. MUST be >= minzoom
+    maxzoom: 30
+
+    # The maximum extent of available map tiles. Bounds MUST define an area
+    # covered by all zoom levels. The bounds are represented in WGS:84
+    # latitude and longitude values, in the order left, bottom, right, top.
+    # Values may be integers or floating point numbers.
+    bounds: [-180.0, -90.0, 180.0, 90.0]
+
+    # Tile extent in tile coordinate space
+    extent: 4096
+
+    # Buffer distance in tile coordinate space to optionally clip geometries
+    buffer: 64
+
+    # Boolean to control if geometries should be clipped or encoded as is
+    clip_geom: true
+
+    # Geometry type
+    geometry_type: GEOMETRY
+
+    # List of columns, that should be encoded as tile properties (required)
+    properties:
+      id: int4
+
+# Associative arrays of function sources
+function_sources:
+  public.function_source:
+    # Function source id (required)
+    id: public.function_source
+
+    # Schema name (required)
+    schema: public
+
+    # Function name (required)
+    function: function_source
+
+    # An integer specifying the minimum zoom level
+    minzoom: 0
+
+    # An integer specifying the maximum zoom level. MUST be >= minzoom
+    maxzoom: 30
+
+    # The maximum extent of available map tiles. Bounds MUST define an area
+    # covered by all zoom levels. The bounds are represented in WGS:84
+    # latitude and longitude values, in the order left, bottom, right, top.
+    # Values may be integers or floating point numbers.
+    bounds: [-180.0, -90.0, 180.0, 90.0]
+
+  public.function_source_query_params:
+    id: public.function_source_query_params
+    schema: public
+    function: function_source_query_params
+    minzoom: 0
+    maxzoom: 30
+    bounds: [-180.0, -90.0, 180.0, 90.0]

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -24,7 +24,7 @@ server {
     gzip_http_version 1.0;
       gzip_comp_level 2;
       gzip_min_length 1100;
-      gzip_buffers     48k;
+      gzip_buffers 128 48k;
       gzip_proxied any;
       gzip_types
         # text/html is always compressed by HttpGzipModule


### PR DESCRIPTION
- Upgrade der verwendeten Postres Datenbank in einer Version mit Postgis
- Setup eines openSource Tile Servers (urbica/martin) als eigenständiger Stack  :tile_server
- Beschleunigung der Startzeiten der Apps, in dem nicht in jeder Komponente wiederholt die Assets gebaut werden müssen (Precompile asstets in dockerfile)
- Setup von Postgis beim Start der DB sicherstellen (im entrypoint.sh)
- postgis- und geo- Gems hinzugefügt um Rails Postgis tauglich zu machen
- für die locale Entwicklung Dockerfile.martin hinzugefügt. Online ist nur die config martin_config.yml im Portainer notwendig
- nginx gzip config repariert
- database.yml auf postgis adapter angepasst
- geoLocations um eine Attribut :coords erweitert, welcher Postgis Point verwendet
- Speicherung vorhandener Lat/Lng Daten im PostGis Format beim speichern eines GeoLocation Datensatzes

BBNAV-68