### PR TITLE
Extend TileServer POI IDs

### DIFF
--- a/db/migrate/20220401074903_update_poi_coords_e_bike_rentals_to_version_2.rb
+++ b/db/migrate/20220401074903_update_poi_coords_e_bike_rentals_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdatePoiCoordsEBikeRentalsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :poi_coords_e_bike_rentals, version: 2, revert_to_version: 1
+  end
+end

--- a/db/migrate/20220401090237_update_poi_coords_e_bike_charging_stations_to_version_2.rb
+++ b/db/migrate/20220401090237_update_poi_coords_e_bike_charging_stations_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdatePoiCoordsEBikeChargingStationsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :poi_coords_e_bike_charging_stations, version: 2, revert_to_version: 1
+  end
+end

--- a/db/migrate/20220401090822_update_poi_coords_bike_repair_shops_to_version_2.rb
+++ b/db/migrate/20220401090822_update_poi_coords_bike_repair_shops_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdatePoiCoordsBikeRepairShopsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :poi_coords_bike_repair_shops, version: 2, revert_to_version: 1
+  end
+end

--- a/db/migrate/20220401090937_update_poi_coords_bike_rentals_to_version_2.rb
+++ b/db/migrate/20220401090937_update_poi_coords_bike_rentals_to_version_2.rb
@@ -1,0 +1,5 @@
+class UpdatePoiCoordsBikeRentalsToVersion2 < ActiveRecord::Migration[5.2]
+  def change
+    update_view :poi_coords_bike_rentals, version: 2, revert_to_version: 1
+  end
+end

--- a/db/views/poi_coords_bike_rentals_v02.sql
+++ b/db/views/poi_coords_bike_rentals_v02.sql
@@ -1,0 +1,15 @@
+ SELECT geo_locations.coords,
+    CONCAT('bike_rentals_', attractions.id) as id,
+    attractions.id as datahub_id,
+    attractions.name,
+    categories.svg_icon,
+    tags.name AS tag_name
+   FROM attractions
+     JOIN taggings ON taggings.taggable_id = attractions.id AND taggings.taggable_type::text = 'Attraction'::text AND taggings.context::text = 'tags'::text
+     JOIN tags ON tags.id = taggings.tag_id
+     JOIN addresses ON addresses.addressable_id = attractions.id AND addresses.addressable_type::text = 'Attraction'::text
+     JOIN geo_locations ON geo_locations.geo_locateable_id = addresses.id AND geo_locations.geo_locateable_type::text = 'Address'::text
+     JOIN data_resource_categories data_resource_categories_attractions_join ON data_resource_categories_attractions_join.data_resource_id = attractions.id AND data_resource_categories_attractions_join.data_resource_type::text = 'PointOfInterest'::text
+     JOIN categories ON categories.id = data_resource_categories_attractions_join.category_id
+     JOIN data_resource_categories ON attractions.id = data_resource_categories.data_resource_id
+  WHERE attractions.type::text = 'PointOfInterest'::text AND data_resource_categories.category_id = 15 AND data_resource_categories.data_resource_type::text = 'PointOfInterest'::text AND tags.name::text = 'Fahrradvermietung'::text;

--- a/db/views/poi_coords_bike_repair_shops_v02.sql
+++ b/db/views/poi_coords_bike_repair_shops_v02.sql
@@ -1,0 +1,15 @@
+ SELECT geo_locations.coords,
+    CONCAT('bike_repair_shops_', attractions.id) as id,
+    attractions.id as datahub_id,
+    attractions.name,
+    categories.svg_icon,
+    tags.name AS tag_name
+   FROM attractions
+     JOIN taggings ON taggings.taggable_id = attractions.id AND taggings.taggable_type::text = 'Attraction'::text AND taggings.context::text = 'tags'::text
+     JOIN tags ON tags.id = taggings.tag_id
+     JOIN addresses ON addresses.addressable_id = attractions.id AND addresses.addressable_type::text = 'Attraction'::text
+     JOIN geo_locations ON geo_locations.geo_locateable_id = addresses.id AND geo_locations.geo_locateable_type::text = 'Address'::text
+     JOIN data_resource_categories data_resource_categories_attractions_join ON data_resource_categories_attractions_join.data_resource_id = attractions.id AND data_resource_categories_attractions_join.data_resource_type::text = 'PointOfInterest'::text
+     JOIN categories ON categories.id = data_resource_categories_attractions_join.category_id
+     JOIN data_resource_categories ON attractions.id = data_resource_categories.data_resource_id
+  WHERE attractions.type::text = 'PointOfInterest'::text AND data_resource_categories.category_id = 15 AND data_resource_categories.data_resource_type::text = 'PointOfInterest'::text AND tags.name::text = 'Werkstatt / Reparatur'::text;

--- a/db/views/poi_coords_e_bike_charging_stations_v02.sql
+++ b/db/views/poi_coords_e_bike_charging_stations_v02.sql
@@ -1,0 +1,15 @@
+ SELECT geo_locations.coords,
+    CONCAT('e_bike_charging_stations_', attractions.id) as id,
+    attractions.id as datahub_id,
+    attractions.name,
+    categories.svg_icon,
+    tags.name AS tag_name
+   FROM attractions
+     JOIN taggings ON taggings.taggable_id = attractions.id AND taggings.taggable_type::text = 'Attraction'::text AND taggings.context::text = 'tags'::text
+     JOIN tags ON tags.id = taggings.tag_id
+     JOIN addresses ON addresses.addressable_id = attractions.id AND addresses.addressable_type::text = 'Attraction'::text
+     JOIN geo_locations ON geo_locations.geo_locateable_id = addresses.id AND geo_locations.geo_locateable_type::text = 'Address'::text
+     JOIN data_resource_categories data_resource_categories_attractions_join ON data_resource_categories_attractions_join.data_resource_id = attractions.id AND data_resource_categories_attractions_join.data_resource_type::text = 'PointOfInterest'::text
+     JOIN categories ON categories.id = data_resource_categories_attractions_join.category_id
+     JOIN data_resource_categories ON attractions.id = data_resource_categories.data_resource_id
+  WHERE attractions.type::text = 'PointOfInterest'::text AND data_resource_categories.category_id = 15 AND data_resource_categories.data_resource_type::text = 'PointOfInterest'::text AND tags.name::text = 'E-Bike-Aufladestation'::text;

--- a/db/views/poi_coords_e_bike_rentals_v02.sql
+++ b/db/views/poi_coords_e_bike_rentals_v02.sql
@@ -1,0 +1,15 @@
+ SELECT geo_locations.coords,
+    CONCAT('e_bike_rentals_', attractions.id) as id,
+    attractions.id as datahub_id,
+    attractions.name,
+    categories.svg_icon,
+    tags.name AS tag_name
+   FROM attractions
+     JOIN taggings ON taggings.taggable_id = attractions.id AND taggings.taggable_type::text = 'Attraction'::text AND taggings.context::text = 'tags'::text
+     JOIN tags ON tags.id = taggings.tag_id
+     JOIN addresses ON addresses.addressable_id = attractions.id AND addresses.addressable_type::text = 'Attraction'::text
+     JOIN geo_locations ON geo_locations.geo_locateable_id = addresses.id AND geo_locations.geo_locateable_type::text = 'Address'::text
+     JOIN data_resource_categories data_resource_categories_attractions_join ON data_resource_categories_attractions_join.data_resource_id = attractions.id AND data_resource_categories_attractions_join.data_resource_type::text = 'PointOfInterest'::text
+     JOIN categories ON categories.id = data_resource_categories_attractions_join.category_id
+     JOIN data_resource_categories ON attractions.id = data_resource_categories.data_resource_id
+  WHERE attractions.type::text = 'PointOfInterest'::text AND data_resource_categories.category_id = 15 AND data_resource_categories.data_resource_type::text = 'PointOfInterest'::text AND tags.name::text = 'E-Bike-Vermietung'::text;

--- a/docker/martin_config.yml
+++ b/docker/martin_config.yml
@@ -70,7 +70,7 @@ table_sources:
       id: int4
       name: string
       svg_icon: string
-      tag_list: string
+      tag_name: string
 
   public.poi_coords_e_bike_charging_stations:
     # Table source id (required)
@@ -117,10 +117,11 @@ table_sources:
 
     # List of columns, that should be encoded as tile properties (required)
     properties:
-      id: int4
+      id: string
+      datahub_id: int4
       name: string
       svg_icon: string
-      tag_list: string
+      tag_name: string
 
   public.poi_coords_e_bike_rentals:
     # Table source id (required)
@@ -167,10 +168,11 @@ table_sources:
 
     # List of columns, that should be encoded as tile properties (required)
     properties:
-      id: int4
+      id: string
+      datahub_id: int4
       name: string
       svg_icon: string
-      tag_list: string
+      tag_name: string
 
   public.poi_coords_bike_rentals:
     # Table source id (required)
@@ -217,10 +219,11 @@ table_sources:
 
     # List of columns, that should be encoded as tile properties (required)
     properties:
-      id: int4
+      id: string
+      datahub_id: int4
       name: string
       svg_icon: string
-      tag_list: string
+      tag_name: string
 
   public.poi_coords_bike_repair_shops:
     # Table source id (required)
@@ -270,7 +273,7 @@ table_sources:
       id: int4
       name: string
       svg_icon: string
-      tag_list: string
+      tag_name: string
 
 # Associative arrays of function sources
 function_sources:


### PR DESCRIPTION
Quick Extension for Tile Server to have different IDs for same POI in different tag-layers.

BBNAV-106

![Bildschirmfoto 2022-04-01 um 09 58 42](https://user-images.githubusercontent.com/90779/161236614-0c22b918-4ff7-42d6-a6cd-9089659624bd.png)
